### PR TITLE
Add ssh package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update -y -q \
     gnupg \
     less \
     m4 \
+    openssh-client \
     pkg-config \
     rlwrap \
     rsync \


### PR DESCRIPTION
Prevent CircleCI from complaining:
> Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.