### PR TITLE
Use (/bin/bash --login -o pipefail -c) as default Dockerfile shell

### DIFF
--- a/base/bare/Dockerfile
+++ b/base/bare/Dockerfile
@@ -81,7 +81,3 @@ ENTRYPOINT ["opam", "exec", "--"]
 CMD ["/bin/bash", "--login"]
 
 LABEL maintainer="erik@martin-dorel.org"
-
-# Restore default shell to fully preserve backward compatibility
-SHELL ["/bin/sh", "-c"]
-# Still, we may remove this line later on.

--- a/base/dual/Dockerfile
+++ b/base/dual/Dockerfile
@@ -102,7 +102,3 @@ ENTRYPOINT ["opam", "exec", "--"]
 CMD ["/bin/bash", "--login"]
 
 LABEL maintainer="erik@martin-dorel.org"
-
-# Restore default shell to fully preserve backward compatibility
-SHELL ["/bin/sh", "-c"]
-# Still, we may remove this line later on.

--- a/base/single/Dockerfile
+++ b/base/single/Dockerfile
@@ -91,7 +91,3 @@ ENTRYPOINT ["opam", "exec", "--"]
 CMD ["/bin/bash", "--login"]
 
 LABEL maintainer="erik@martin-dorel.org"
-
-# Restore default shell to fully preserve backward compatibility
-SHELL ["/bin/sh", "-c"]
-# Still, we may remove this line later on.


### PR DESCRIPTION
Among other things, this allows:
* using the `travis_retry command args…` feature from `/etc/profile.d/travis.sh`
* using Bash specific features

If/when we merge this, all `coqorg/base` images should be rebuilt (by a manual GitLab CI pipeline).