### PR TITLE
bump opam to 2.1

### DIFF
--- a/base/bare/Dockerfile
+++ b/base/bare/Dockerfile
@@ -39,7 +39,7 @@ RUN cat /proc/cpuinfo /proc/meminfo \
   && set -x \
   && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
   && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
-  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && curl -fsSL https://opam-3.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
   && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
   && mv "/tmp/${binary}" /usr/local/bin/opam \
   && chmod a+x /usr/local/bin/opam \

--- a/base/dual/Dockerfile
+++ b/base/dual/Dockerfile
@@ -33,7 +33,7 @@ RUN cat /proc/cpuinfo /proc/meminfo \
   && set -x \
   && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
   && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
-  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && curl -fsSL https://opam-3.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
   && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
   && mv "/tmp/${binary}" /usr/local/bin/opam \
   && chmod a+x /usr/local/bin/opam \

--- a/base/single/Dockerfile
+++ b/base/single/Dockerfile
@@ -33,7 +33,7 @@ RUN cat /proc/cpuinfo /proc/meminfo \
   && set -x \
   && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
   && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
-  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && curl -fsSL https://opam-3.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
   && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
   && mv "/tmp/${binary}" /usr/local/bin/opam \
   && chmod a+x /usr/local/bin/opam \

--- a/images.yml
+++ b/images.yml
@@ -3,7 +3,7 @@ base_url: 'https://gitlab.com/coq-community/docker-base'
 active: true
 docker_repo: 'coqorg/base'
 args:
-  OPAM_VERSION: '2.0.9'
+  OPAM_VERSION: '2.1.2'
   # pass these args albeit they are not used by all Dockerfiles:
   OCAMLFIND_VERSION: '1.9.1'
   DUNE_VERSION: '2.9.1'


### PR DESCRIPTION
@erikmd opam 2.1 has the following advantages:
- automatically installs depext, see for example https://github.com/math-comp/analysis/pull/609#issuecomment-1080720326 and the resulting fix
- much faster in resolving constraints involving hierarchy builder https://github.com/ocaml/opam/issues/4495

Fixes: coq-community/docker-coq#38