### PR TITLE
Upgrade Dune to 3.5.0

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -6,7 +6,7 @@ args:
   OPAM_VERSION: '2.1.3'
   # pass these args albeit they are not used by all Dockerfiles:
   OCAMLFIND_VERSION: '1.9.1'
-  DUNE_VERSION: '3.4.1'
+  DUNE_VERSION: '3.5.0'
   ZARITH_VERSION: '1.12'
 images:
   # TODO: remove latest after the migration time


### PR DESCRIPTION
Dune 3.5.0 has been released with the `(stdlib no)` feature. It would be great if the images could be upgraded.