### PR TITLE
use the production opam.ocaml.org URL to get PGP keys

### DIFF
--- a/base/bare/Dockerfile
+++ b/base/bare/Dockerfile
@@ -39,7 +39,7 @@ RUN cat /proc/cpuinfo /proc/meminfo \
   && set -x \
   && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
   && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
-  && curl -fsSL https://opam-3.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
   && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
   && mv "/tmp/${binary}" /usr/local/bin/opam \
   && chmod a+x /usr/local/bin/opam \

--- a/base/dual/Dockerfile
+++ b/base/dual/Dockerfile
@@ -33,7 +33,7 @@ RUN cat /proc/cpuinfo /proc/meminfo \
   && set -x \
   && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
   && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
-  && curl -fsSL https://opam-3.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
   && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
   && mv "/tmp/${binary}" /usr/local/bin/opam \
   && chmod a+x /usr/local/bin/opam \

--- a/base/single/Dockerfile
+++ b/base/single/Dockerfile
@@ -33,7 +33,7 @@ RUN cat /proc/cpuinfo /proc/meminfo \
   && set -x \
   && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
   && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
-  && curl -fsSL https://opam-3.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
   && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
   && mv "/tmp/${binary}" /usr/local/bin/opam \
   && chmod a+x /usr/local/bin/opam \


### PR DESCRIPTION
opam-3.ocaml.org was introduced as a temporary measure in 930e5b17745a85384574fe00900731271f7a85c7 (#17), but that server will decommissioned quite soon (ocaml/infrastructure#19) so this will avoid build breakage for Coq.