### PR TITLE
feat: Bump `coqorg/base`'s parent to `debian:12-slim` (bookworm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This repository provides parent images for [Docker](https://www.docker.com/) images of the [Coq](https://github.com/coq/coq) proof assistant.
 
-These images are based on [Debian 11 Slim](https://hub.docker.com/_/debian/):
+These images are based on [Debian 12 Slim](https://hub.docker.com/_/debian/):
 
 |   | GitHub repo                                                             | Type          | Docker Hub                                             |
 |---|-------------------------------------------------------------------------|---------------|--------------------------------------------------------|

--- a/base/bare/Dockerfile
+++ b/base/bare/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:12-slim
 
 # This 'bare' image does not have any OCaml compiler Docker layer:
 # * it keeps all other layers (APT packages, OPAM 2.0, etc.)

--- a/base/dual/Dockerfile
+++ b/base/dual/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:12-slim
 
 ARG OPAM_VERSION
 ENV OPAM_VERSION=${OPAM_VERSION}

--- a/base/single/Dockerfile
+++ b/base/single/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11-slim
+FROM debian:12-slim
 
 ARG OPAM_VERSION
 ENV OPAM_VERSION=${OPAM_VERSION}

--- a/images.yml
+++ b/images.yml
@@ -3,12 +3,14 @@ base_url: 'https://gitlab.com/coq-community/docker-base'
 active: true
 docker_repo: 'coqorg/base'
 args:
-  OPAM_VERSION: '2.1.6'
+  OPAM_VERSION: '2.2.0'
   # pass these args albeit they are not used by all Dockerfiles:
   OCAMLFIND_VERSION: '1.9.6'
+  # NOTE: do not bump dune's version before this issue is resolved:
+  # https://github.com/ocaml/dune/pull/9895#issuecomment-2207889822
   DUNE_VERSION: '3.13.1'
-  ZARITH_VERSION: '1.13'
-  NUM_VERSION: '1.5'
+  ZARITH_VERSION: '1.14'
+  NUM_VERSION: '1.5-1'
 propagate:
   coq:
     api_token_env_var: 'DOCKER_COQ_TOKEN'


### PR DESCRIPTION
Also:
- Bump opam's version to 2.2.0 <https://opam.ocaml.org/blog/opam-2-2-0/>
- Bump zarith's version to 1.14
- Bump num's version to 1.5-1

cf. the [announcement on Discourse](https://coq.discourse.group/t/ann-docker-coq-bump-to-debian-12-opam-2-2-0/2385)

Close #24 