### PR TITLE
feat: Deploy `rocq/base:rocq_*` parent images

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,10 @@ These images are based on [Debian 12 Slim](https://hub.docker.com/_/debian/):
 
 This Dockerfile repository is [mirrored on GitLab](https://gitlab.com/coq-community/docker-base), but [issues](https://github.com/coq-community/docker-base/issues) and [pull requests](https://github.com/coq-community/docker-base/pulls) are tracked on GitHub.
 
+Note that these base images do **not** contain the Rocq Prover nor the Coq proof assistant.
+They just contain a **sudo** user with UID=GID=1000 and /home/rocq or /home/coq as homedir,
+as well as one **opam** switch, and some minimal **apt** and **opam** dependencies.
+The "bare" images do **not** contain any **opam** switch, just the **opam** binary.
+The default entrypoint is `ENTRYPOINT ["opam", "exec", "--"]` for all these images.
+
 <!-- tags -->

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# coqorg/base
+# rocq/base
 
-[![tags](https://img.shields.io/badge/tags%20on-docker%20hub-blue.svg)](https://hub.docker.com/r/coqorg/base#supported-tags "Supported tags on Docker Hub")
+[![tags](https://img.shields.io/badge/tags%20on-docker%20hub-blue.svg)](https://hub.docker.com/r/rocq/base#supported-tags "Supported tags on Docker Hub")
 [![pipeline status](https://gitlab.com/coq-community/docker-base/badges/master/pipeline.svg)](https://gitlab.com/coq-community/docker-base/-/pipelines)
-[![pulls](https://img.shields.io/docker/pulls/coqorg/base.svg)](https://hub.docker.com/r/coqorg/base "Number of pulls from Docker Hub")
-[![stars](https://img.shields.io/docker/stars/coqorg/base.svg)](https://hub.docker.com/r/coqorg/base "Star the image on Docker Hub")  
+[![pulls](https://img.shields.io/docker/pulls/rocq/base.svg)](https://hub.docker.com/r/rocq/base "Number of pulls from Docker Hub")
+[![stars](https://img.shields.io/docker/stars/rocq/base.svg)](https://hub.docker.com/r/rocq/base "Star the image on Docker Hub")  
 [![dockerfile](https://img.shields.io/badge/dockerfile%20on-github-blue.svg)](https://github.com/coq-community/docker-base "Dockerfile source repository")
-[![coq](https://img.shields.io/badge/see%20also-coqorg%2Fcoq-brightgreen.svg)](https://hub.docker.com/r/coqorg/coq "Docker images of Coq")
+[![coq](https://img.shields.io/badge/see%20also-rocq%2Frocq--prover-brightgreen.svg)](https://hub.docker.com/r/rocq/rocq-prover "Docker images of Rocq")
 
 This repository provides parent images for [Docker](https://www.docker.com/) images of the [Coq](https://github.com/coq/coq) proof assistant.
 
 These images are based on [Debian 12 Slim](https://hub.docker.com/_/debian/):
 
-|   | GitHub repo                                                             | Type          | Docker Hub                                             |
-|---|-------------------------------------------------------------------------|---------------|--------------------------------------------------------|
-|   | [docker-coq-action](https://github.com/coq-community/docker-coq-action) | GitHub Action | N/A                                                    |
-|   | [docker-coq](https://github.com/coq-community/docker-coq)               | Dockerfile    | [`coqorg/coq`](https://hub.docker.com/r/coqorg/coq/)   |
-| ⊙ | [docker-base](https://github.com/coq-community/docker-base)             | Dockerfile    | [`coqorg/base`](https://hub.docker.com/r/coqorg/base/) |
-| ↳ | Debian                                                                  | Linux distro  | [`debian`](https://hub.docker.com/_/debian/)           |
+|   | GitHub repo                                                             | Type          | Docker Hub                                                       |
+|---|-------------------------------------------------------------------------|---------------|------------------------------------------------------------------|
+|   | [docker-coq-action](https://github.com/coq-community/docker-coq-action) | GitHub Action | N/A                                                              |
+|   | [docker-rocq](https://github.com/coq-community/docker-rocq)             | Dockerfile    | [`rocq/rocq-prover`](https://hub.docker.com/r/rocq/rocq-prover/) |
+| ⊙ | [docker-base](https://github.com/coq-community/docker-base)             | Dockerfile    | [`rocq/base`](https://hub.docker.com/r/rocq/base/)               |
+| ↳ | Debian                                                                  | Linux distro  | [`debian`](https://hub.docker.com/_/debian/)                     |
 
 This Dockerfile repository is [mirrored on GitLab](https://gitlab.com/coq-community/docker-base), but [issues](https://github.com/coq-community/docker-base/issues) and [pull requests](https://github.com/coq-community/docker-base/pulls) are tracked on GitHub.
 

--- a/base/rocq-bare/Dockerfile
+++ b/base/rocq-bare/Dockerfile
@@ -1,0 +1,78 @@
+FROM debian:12-slim
+
+# This 'bare' image does not have any OCaml compiler Docker layer:
+# * it keeps all other layers (APT packages, OPAM 2.0, etc.)
+# * it also keeps some env. variables (OPAM_VERSION, NJOBS, OPAMPRECISETRACKING)
+# * it can be used to build children images from rocq/rocq-prover by multi-stage build
+#   and copy the .opam folder in the very end.
+
+ARG OPAM_VERSION
+ENV OPAM_VERSION=${OPAM_VERSION}
+
+SHELL ["/bin/bash", "--login", "-o", "pipefail", "-c"]
+
+# hadolint ignore=DL3008
+RUN cat /proc/cpuinfo /proc/meminfo \
+  && [ -n "${OPAM_VERSION}" ] \
+  && apt-get update -y -q \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+    autoconf \
+    automake \
+    bubblewrap \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    # gnupg is temporarily installed and will not be kept in the image
+    gnupg \
+    less \
+    libgmp-dev \
+    m4 \
+    openssh-client \
+    pkg-config \
+    rlwrap \
+    rsync \
+    sudo \
+    time \
+    unzip \
+  && binary="opam-${OPAM_VERSION}-$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]')" \
+  && set -x \
+  && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
+  && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
+  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
+  && mv "/tmp/${binary}" /usr/local/bin/opam \
+  && chmod a+x /usr/local/bin/opam \
+  && rm -f "/tmp/${binary}.sig" \
+  && rm -fr /root/.gnupg \
+  && DEBIAN_FRONTEND=noninteractive apt-get purge -y -q --auto-remove gnupg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Use Docker build args to set the UID/GID
+ARG guest_uid=1000
+ARG guest_gid=${guest_uid}
+
+# Add rocq group and user with sudo perms
+# hadolint ignore=SC2174
+RUN groupadd -g ${guest_gid} rocq \
+  && useradd --no-log-init -m -s /bin/bash -g rocq -G sudo -p '' -u ${guest_uid} rocq \
+  # Create dirs for user scripts
+  && mkdir -m 775 -p -v /home/rocq/bin /home/rocq/.local/bin \
+  && chown rocq:rocq /home/rocq/bin /home/rocq/.local /home/rocq/.local/bin
+
+# Load travis.sh, umask.sh at login
+COPY travis.sh umask.sh /etc/profile.d/
+
+WORKDIR /home/rocq
+
+USER rocq
+
+ENV NJOBS="2"
+ENV OPAMPRECISETRACKING="1"
+
+ENTRYPOINT ["opam", "exec", "--"]
+
+CMD ["/bin/bash", "--login"]
+
+LABEL maintainer="erik@martin-dorel.org"

--- a/base/rocq-single/Dockerfile
+++ b/base/rocq-single/Dockerfile
@@ -1,0 +1,106 @@
+FROM debian:12-slim
+
+ARG OPAM_VERSION
+ENV OPAM_VERSION=${OPAM_VERSION}
+
+SHELL ["/bin/bash", "--login", "-o", "pipefail", "-c"]
+
+# hadolint ignore=DL3008
+RUN cat /proc/cpuinfo /proc/meminfo \
+  && [ -n "${OPAM_VERSION}" ] \
+  && apt-get update -y -q \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+    autoconf \
+    automake \
+    bubblewrap \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    # gnupg is temporarily installed and will not be kept in the image
+    gnupg \
+    less \
+    libgmp-dev \
+    m4 \
+    openssh-client \
+    pkg-config \
+    rlwrap \
+    rsync \
+    sudo \
+    time \
+    unzip \
+  && binary="opam-${OPAM_VERSION}-$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]')" \
+  && set -x \
+  && curl -fSL -o "/tmp/${binary}" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}" \
+  && curl -fSL -o "/tmp/${binary}.sig" "https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}/${binary}.sig" \
+  && curl -fsSL https://opam.ocaml.org/opam-dev-pubkey.pgp | gpg --batch --import \
+  && gpg --batch --verify "/tmp/${binary}.sig" "/tmp/${binary}" \
+  && mv "/tmp/${binary}" /usr/local/bin/opam \
+  && chmod a+x /usr/local/bin/opam \
+  && rm -f "/tmp/${binary}.sig" \
+  && rm -fr /root/.gnupg \
+  && DEBIAN_FRONTEND=noninteractive apt-get purge -y -q --auto-remove gnupg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Use Docker build args to set the UID/GID
+ARG guest_uid=1000
+ARG guest_gid=${guest_uid}
+
+# Add rocq group and user with sudo perms
+# hadolint ignore=SC2174
+RUN groupadd -g ${guest_gid} rocq \
+  && useradd --no-log-init -m -s /bin/bash -g rocq -G sudo -p '' -u ${guest_uid} rocq \
+  # Create dirs for user scripts
+  && mkdir -m 775 -p -v /home/rocq/bin /home/rocq/.local/bin \
+  && chown rocq:rocq /home/rocq/bin /home/rocq/.local /home/rocq/.local/bin
+
+# Load travis.sh, umask.sh at login
+COPY travis.sh umask.sh /etc/profile.d/
+
+WORKDIR /home/rocq
+
+USER rocq
+
+ENV NJOBS="2"
+ENV OPAMPRECISETRACKING="1"
+ARG COMPILER
+ENV COMPILER=${COMPILER}
+# The following variable is unneeded for ocaml < 4.12
+# Otherwise, use e.g.:
+# --build-arg=COMPILER=4.12.0+flambda
+# --build-arg=COMPILER_PACKAGE=ocaml-variants.4.12.0+options,ocaml-option-flambda
+ARG COMPILER_PACKAGE
+ARG OCAMLFIND_VERSION
+ENV OCAMLFIND_VERSION=${OCAMLFIND_VERSION}
+ARG DUNE_VERSION
+ENV DUNE_VERSION=${DUNE_VERSION}
+
+ARG NUM_VERSION=0
+# or 1.4
+
+ARG ZARITH_VERSION
+ENV ZARITH_VERSION=${ZARITH_VERSION}
+
+# hadolint ignore=SC2046
+RUN set -x \
+  && opam init --auto-setup --yes --bare --disable-sandboxing \
+  && opam switch create --jobs=${NJOBS} ${COMPILER} ${COMPILER_PACKAGE:+--package=}${COMPILER_PACKAGE} \
+  && eval $(opam env) \
+  && opam repository add --all-switches --set-default rocq-released https://coq.inria.fr/opam/released \
+  && opam update -y \
+  && opam install -y -j 1 opam-depext \
+  && opam pin add -n -k version ocamlfind ${OCAMLFIND_VERSION} \
+  && opam pin add -n -k version dune ${DUNE_VERSION} \
+  && opam pin add -n -k version num ${NUM_VERSION} \
+  && opam pin add -n -k version zarith ${ZARITH_VERSION} \
+  && opam install -y -v -j ${NJOBS} ocamlfind dune num zarith \
+  && opam clean -a -c -s --logs \
+  && chmod -R g=u /home/rocq/.opam \
+  && opam config list && opam list
+
+ENTRYPOINT ["opam", "exec", "--"]
+
+CMD ["/bin/bash", "--login"]
+
+LABEL maintainer="erik@martin-dorel.org"

--- a/images.yml
+++ b/images.yml
@@ -17,39 +17,115 @@ propagate:
     strategy:
       - when: 'rebuild-all'
         mode: 'rebuild-all'
-      # TODO: improve with ocaml keywords in docker-coq?
+      # don't propagate if "all keywords \subset {rocq}"
+      - when: 'forall'
+        expr: '{keywords[/#/,][#,]}'
+        subset: 'rocq'
+        mode: 'nil'
+      # propagate if "one keyword = coq"
+      - when: 'exists'
+        expr: '{keywords[/#/,][#,]}'
+        subset: 'coq'
+        mode: 'rebuild-all'
+      - # when OPTIONAL for last rule
+        mode: 'nil'
+  # TODO: we may want to add ocaml keywords in docker-rocq
+  rocq:
+    api_token_env_var: 'DOCKER_ROCQ_TOKEN'
+    gitlab_domain: 'gitlab.com'
+    gitlab_project: '63032389'
+    strategy:
+      - when: 'rebuild-all'
+        mode: 'rebuild-all'
+      # don't propagate if "all keywords \subset {coq}"
+      - when: 'forall'
+        expr: '{keywords[/#/,][#,]}'
+        subset: 'coq'
+        mode: 'nil'
+      # propagate if "one keyword = rocq"
+      - when: 'exists'
+        expr: '{keywords[/#/,][#,]}'
+        subset: 'rocq'
+        mode: 'rebuild-all'
+      - # when OPTIONAL for last rule
+        mode: 'nil'
 images:
-  - matrix:
+  - matrix: &matrix_412_up_flambda
       tag:
         - '5.0.0-flambda'
         - '4.14.2-flambda'
         - '4.13.1-flambda'
         - '4.12.1-flambda'
-    build:
+    build: &build_412_up_flambda_rocq
+      keywords: ['rocq']
       context: './base'
-      dockerfile: './coq-single/Dockerfile'
+      dockerfile: './rocq-single/Dockerfile'
       args:
         COMPILER: '{matrix[tag][//-/+]}'
         COMPILER_PACKAGE: 'ocaml-variants.{matrix[tag][%-*]}+options,ocaml-option-flambda'
       tags:
-        - tag: 'coq_{matrix[tag]}'
+        - tag: 'rocq_{matrix[tag]}'
   - matrix:
+      <<: *matrix_412_up_flambda
+    build:
+      <<: *build_412_up_flambda_rocq
+      keywords: ['coq']
+      dockerfile: './coq-single/Dockerfile'
+      tags:
+        - tag: 'coq_{matrix[tag]}'
+  - matrix: &matrix_408_up_flambda
       tag:
         - '4.11.2-flambda'
         - '4.10.2-flambda'
         - '4.09.1-flambda'
         - '4.08.1-flambda'
-    build:
+    build: &build_408_up_flambda
+      keywords: ['rocq']
       context: './base'
-      dockerfile: './coq-single/Dockerfile'
+      dockerfile: './rocq-single/Dockerfile'
       args:
         COMPILER: '{matrix[tag][//-/+]}'
       tags:
+        - tag: 'rocq_{matrix[tag]}'
+  - matrix:
+      <<: *matrix_408_up_flambda
+    build:
+      <<: *build_408_up_flambda
+      keywords: ['coq']
+      dockerfile: './coq-single/Dockerfile'
+      tags:
         - tag: 'coq_{matrix[tag]}'
+  ####################################################
+  # compiler without flambda, for rocq-native images #
+  ####################################################
+  - matrix: &matrix_412_up
+      tag:
+        - '5.0.0'
+        - '4.13.1'
+    build: &build_412_up_rocq
+      keywords: ['rocq']
+      context: './base'
+      dockerfile: './rocq-single/Dockerfile'
+      args:
+        COMPILER: '{matrix[tag]}'
+      tags:
+        - tag: 'rocq_{matrix[tag]}'
+  - matrix:
+      <<: *matrix_412_up
+    build:
+      <<: *build_412_up_rocq
+      keywords: ['coq']
+      dockerfile: './coq-single/Dockerfile'
+      tags:
+        - tag: 'coq_{matrix[tag]}'
+  ##########################################################
+  # !!! # "rocq-prover" requires "ocaml" >= "4.09.0" # !!! #
+  ##########################################################
   - matrix:
       tag:
         - '4.07.1-flambda'
     build:
+      keywords: ['coq']
       context: './base'
       dockerfile: './coq-single/Dockerfile'
       args:
@@ -57,21 +133,14 @@ images:
         OCAMLFIND_VERSION: '1.9.1'
       tags:
         - tag: 'coq_{matrix[tag]}'
-  - matrix:
-      tag:
-        - '5.0.0'
-        - '4.13.1'
-    build:
-      context: './base'
-      dockerfile: './coq-single/Dockerfile'
-      args:
-        COMPILER: '{matrix[tag]}'
-      tags:
-        - tag: 'coq_{matrix[tag]}'
+  ####################################################
+  # compiler without flambda (for coq-native images) #
+  ####################################################
   - matrix:
       tag:
         - '4.07.1'
     build:
+      keywords: ['coq']
       context: './base'
       dockerfile: './coq-single/Dockerfile'
       args:
@@ -82,6 +151,7 @@ images:
   - matrix:
       tag: ['4.05.0']
     build:
+      keywords: ['coq']
       context: './base'
       dockerfile: './coq-single/Dockerfile'
       args:
@@ -94,6 +164,7 @@ images:
   - matrix:
       tag: ['4.02.3']
     build:
+      keywords: ['coq']
       context: './base'
       dockerfile: './coq-single/Dockerfile'
       args:
@@ -106,6 +177,7 @@ images:
   - matrix:
       tag: ['bare']
     build:
+      keywords: ['coq']
       context: './base'
       dockerfile: './coq-bare/Dockerfile'
       tags:

--- a/images.yml
+++ b/images.yml
@@ -65,14 +65,6 @@ images:
         COMPILER_PACKAGE: 'ocaml-variants.{matrix[tag][%-*]}+options,ocaml-option-flambda'
       tags:
         - tag: 'rocq_{matrix[tag]}'
-  - matrix:
-      <<: *matrix_412_up_flambda
-    build:
-      <<: *build_412_up_flambda_rocq
-      keywords: ['coq']
-      dockerfile: './coq-single/Dockerfile'
-      tags:
-        - tag: 'coq_{matrix[tag]}'
   - matrix: &matrix_408_up_flambda
       tag:
         - '4.11.2-flambda'
@@ -87,17 +79,9 @@ images:
         COMPILER: '{matrix[tag][//-/+]}'
       tags:
         - tag: 'rocq_{matrix[tag]}'
-  - matrix:
-      <<: *matrix_408_up_flambda
-    build:
-      <<: *build_408_up_flambda
-      keywords: ['coq']
-      dockerfile: './coq-single/Dockerfile'
-      tags:
-        - tag: 'coq_{matrix[tag]}'
-  ####################################################
-  # compiler without flambda, for rocq-native images #
-  ####################################################
+  #####################################################
+  # compilers without flambda, for rocq-native images #
+  #####################################################
   - matrix: &matrix_412_up
       tag:
         - '5.0.0'
@@ -110,6 +94,25 @@ images:
         COMPILER: '{matrix[tag]}'
       tags:
         - tag: 'rocq_{matrix[tag]}'
+  ##########################################################
+  # !!! # "rocq-prover" requires "ocaml" >= "4.09.0" # !!! #
+  ##########################################################
+  - matrix:
+      <<: *matrix_412_up_flambda
+    build:
+      <<: *build_412_up_flambda_rocq
+      keywords: ['coq']
+      dockerfile: './coq-single/Dockerfile'
+      tags:
+        - tag: 'coq_{matrix[tag]}'
+  - matrix:
+      <<: *matrix_408_up_flambda
+    build:
+      <<: *build_408_up_flambda
+      keywords: ['coq']
+      dockerfile: './coq-single/Dockerfile'
+      tags:
+        - tag: 'coq_{matrix[tag]}'
   - matrix:
       <<: *matrix_412_up
     build:
@@ -118,9 +121,6 @@ images:
       dockerfile: './coq-single/Dockerfile'
       tags:
         - tag: 'coq_{matrix[tag]}'
-  ##########################################################
-  # !!! # "rocq-prover" requires "ocaml" >= "4.09.0" # !!! #
-  ##########################################################
   - matrix:
       tag:
         - '4.07.1-flambda'
@@ -174,11 +174,19 @@ images:
         OCAMLFIND_VERSION: '1.9.1'
       tags:
         - tag: 'coq_{matrix[tag]}'
-  - matrix:
+  - matrix: &matrix_bare
       tag: ['bare']
-    build:
-      keywords: ['coq']
+    build: &build_bare_rocq
+      keywords: ['rocq']
       context: './base'
+      dockerfile: './rocq-bare/Dockerfile'
+      tags:
+        - tag: 'rocq_{matrix[tag]}'
+  - matrix:
+      <<: *matrix_bare
+    build:
+      <<: *build_bare_rocq
+      keywords: ['coq']
       dockerfile: './coq-bare/Dockerfile'
       tags:
         - tag: 'coq_{matrix[tag]}'


### PR DESCRIPTION
Follows-up: https://github.com/coq-community/docker-coq/pull/74

3rd step in the release of `rocq/rocq-prover:9.0-rc1`

* Add 2 Dockerfiles containing a /home/rocq directory
* Add docker-keeper keywords to categorize all images
* Update README.md as well