### PR TITLE
feat: Bump dune (3.17.2 -> 3.21.0)

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -6,7 +6,7 @@ args:
   OPAM_VERSION: '2.3.0'
   # pass these args albeit they are not used by all Dockerfiles:
   OCAMLFIND_VERSION: '1.9.6'
-  DUNE_VERSION: '3.17.2'
+  DUNE_VERSION: '3.21.0'
   ZARITH_VERSION: '1.14'
   NUM_VERSION: '1.5-1'
 propagate:


### PR DESCRIPTION
Dune 3.21 introduced the `(lang rocq)` build mode. It would be great if the images could be upgraded.