### PR TITLE
Revert update to safer Dune version.

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -6,7 +6,7 @@ args:
   OPAM_VERSION: '2.3.0'
   # pass these args albeit they are not used by all Dockerfiles:
   OCAMLFIND_VERSION: '1.9.6'
-  DUNE_VERSION: '3.23.1'
+  DUNE_VERSION: '3.21.1'
   ZARITH_VERSION: '1.14'
   NUM_VERSION: '1.5-1'
 propagate:


### PR DESCRIPTION
Dune > 3.21 apparently has regressions impacting Rocq users. See https://github.com/rocq-prover/docker-opam-action/issues/108#issuecomment-4624151555.